### PR TITLE
docs: gcloud beta no longer required

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To use the module:
 2.  Add settings to connect to the repository to .npmrc. Use the output from the
     following command:
 
-    `$ gcloud beta artifacts print-settings npm`
+    `$ gcloud artifacts print-settings npm`
 
     ```
     registry=https://LOCATION-npm.pkg.dev/PROJECT_ID/REPOSITORY_ID/

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Artifact Registry.
 For more details, see
 https://cloud.google.com/artifact-registry/docs/nodejs/authentication
 
-The module automatically searches for credentials from the envrironment and authenticates to Artifact Registry. It looks for
+The module automatically searches for credentials from the environment and authenticates to Artifact Registry. It looks for
 credentials in the following order:
 1. [Google Application Default Credentials](https://developers.google.com/accounts/docs/application-default-credentials).
 2. The current active account logged in via `gcloud auth login`.


### PR DESCRIPTION
`gcloud beta` is no longer required to use the `artifacts print-settings npm` command.

It is supported in the latest Google Cloud SDK release.
https://cloud.google.com/sdk/gcloud/reference/artifacts/print-settings/npm