### PR TITLE
chore(deps): update google-auth-library from ^5.0.0 to ^7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Google LLC",
   "license": "Apache-2.0",
   "dependencies": {
-    "google-auth-library": "^5.0.0"
+    "google-auth-library": "^7.0.0"
   },
   "bin": {
     "artifactregistry-auth": "./src/main.js"


### PR DESCRIPTION
There are 5 high severity vulnerabilities related to [google-auth-library](https://github.com/googleapis/google-auth-library-nodejs#readme) ^5.0.0 logged by npm when installing. Running a `npm audit` results in the below screenshot.

<img width="504" alt="Screenshot 2021-04-06 at 11 13 38" src="https://user-images.githubusercontent.com/4893048/113695797-2e0b0880-96c9-11eb-8eef-38ed9648c92d.png">


Updating google-auth-library to `^7.0.0` should resolve these vulnerability.

Check the [CHANGELOG.md](https://github.com/googleapis/google-auth-library-nodejs/blob/master/CHANGELOG.md) for google-auth-library for any breaking changes from `5.0.0` to `7.0.0`

[6.0.0](https://github.com/googleapis/google-auth-library-nodejs/blob/master/CHANGELOG.md#-breaking-changes-1)
[7.0.0](https://github.com/googleapis/google-auth-library-nodejs/blob/master/CHANGELOG.md#-breaking-changes)

You might want to look into enabling some of GitHub security features that are free for open source projects. These may alert this project to future security issues.

- [Secure Coding - Code Scanning](https://docs.github.com/en/code-security/secure-coding/about-code-scanning)
- [Supply Chain Security - Managing vulnerabilities in your project's dependencies](https://docs.github.com/en/code-security/supply-chain-security/managing-vulnerabilities-in-your-projects-dependencies)