### PR TITLE
Hide detailed logs behind --verbose

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -15,6 +15,7 @@
 const {GoogleAuth} = require('google-auth-library');
 const util = require('util');
 const exec = util.promisify(require('child_process').exec);
+const {logger} = require('./logger');
 
 /**
  * Automatically choose the right client credentials based on the environment.
@@ -25,22 +26,20 @@ async function getCreds() {
   try {
     console.log(`Retrieving application default credentials...`)
     const creds = await getApplicationDefaultCredentials();
-    console.log(`Retrieved application default credentials.`)
     return creds;
   } catch (err) {
-    console.log(`Failed to retrieve application default credentials: ${err.message}.`);
+    logger.verbose(`Failed to retrieve application default credentials: ${err.message}. Fall back to gcloud credentials.`);
   }
   try {
     console.log(`Retrieving credentials from gcloud...`)
     const creds = await getGcloudCredentials();
-    console.log(`Retrieved credentials from the current active account from gcloud.`)
     return creds;
   } catch (err) {
-    console.log(`Failed to retrieve credentials from gcloud: ${err.message}.`)
+    logger.verbose(`Failed to retrieve credentials from gcloud: ${err.message}.`)
   }
   throw new Error(
       'Fail to get credentials. Please run: \n' +
-      '`gcloud auth application-default login` or \n' +
+      '`gcloud auth application-default login`, `gcloud auth login`, or \n' +
       '`export GOOGLE_APPLICATION_CREDENTIALS=<path/to/service/account/key>`');
 }
 

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,26 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+let logger = {
+  logVerbose: false,
+  verbose: function(content) {
+    if (this.logVerbose) {
+    	console.log(content);
+    }
+  }
+}
+
+module.exports = {
+  logger,
+};

--- a/src/main.js
+++ b/src/main.js
@@ -18,6 +18,7 @@ const os = require('os');
 const yargs = require('yargs/yargs')
 const { hideBin } = require('yargs/helpers')
 const auth = require('./auth');
+const { logger } = require('./logger');
 const update = require('./update');
 
 /**
@@ -52,9 +53,15 @@ async function main() {
         describe: 'Path to the .npmrc file to write credentials to, usually the user-level npmrc file',
         default: `${os.homedir()}/.npmrc`
       })
+      .option('verbose', {
+        type: 'boolean',
+        describe: 'Set log level to verbose',
+        default: false
+      })
       .help()
       .argv;
 
+    logger.logVerbose = allArgs.verbose;
     const configPath = allArgs.config;
     const creds = await auth.getCreds();
     if (configPath) {
@@ -63,7 +70,8 @@ async function main() {
       await update.updateConfigFile(configPath, creds);
     } else {
       await update.updateConfigFiles(allArgs.repoConfig, allArgs.credentialConfig, creds);
-    }    
+    }
+    console.log("Success!");
   } catch (err) {
     console.error(err);
     process.exit(1);

--- a/src/update.js
+++ b/src/update.js
@@ -16,6 +16,7 @@ const fs = require('fs');
 const path = require('path');
 const readline = require('readline');
 const c = require('./config');
+const {logger} = require('./logger');
 
 /**
  * Update the project and user npmrc files.
@@ -63,10 +64,10 @@ async function updateConfigFiles(fromConfigPath, toConfigPath, creds) {
         });
         break;
       case c.configType.AuthToken:
-        console.warn(`Found an auth token for the registry ${config.registry} in the project npmrc file. Moving it to the user npmrc file...`);
+        logger.verbose(`Found an auth token for the registry ${config.registry} in the project npmrc file. Moving it to the user npmrc file...`);
         break;
       case c.configType.Password:
-        console.warn(`Found password for the registry ${config.registry} in the project npmrc file. Moving it to the user npmrc file...`);
+        logger.verbose(`Found password for the registry ${config.registry} in the project npmrc file. Moving it to the user npmrc file...`);
         registryAuthConfigs.set(config.registry, config);
         break;
       default:


### PR DESCRIPTION
without `--verbose`:

```
hzyi@hzyi-laptop:~/artifact-registry-npm-tools$ ./src/main.js \
  --repo-config=../artifactregistry/npmstaging/test/.npmrc --verbose
Retrieving application default credentials...
Retrieving credentials from gcloud...
Success!
```

with `--verbose`:

```
hzyi@hzyi-laptop:~/artifact-registry-npm-tools$ ./src/main.js \
  --repo-config=../artifactregistry/npmstaging/slashtest/.npmrc --verbose
Retrieving application default credentials...
Failed to retrieve application default credentials: Could not load the default credentials. Browse to https://cloud.google.com/docs/authentication/getting-started for more information.. Fall back to gcloud credentials.
Retrieving credentials from gcloud...
Success!

```