### PR TITLE
fix: allow some URL safe characters in the scoep regex

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 
-const registryRegex = /(@[a-zA-Z0-9-]+:)?registry=https:(\/\/[a-zA-Z0-9-]+[-]npm[.]pkg[.]dev\/.*\/)/;
+const registryRegex = /(@[a-zA-Z0-9-*~][a-zA-Z0-9-*._~]*:)?registry=https:(\/\/[a-zA-Z0-9-]+[-]npm[.]pkg[.]dev\/.*\/)/;
 const authTokenRegex = /(\/\/[a-zA-Z0-9-]+[-]npm[.]pkg[.]dev\/.*\/):_authToken=(.*)/;
 const passwordRegex = /(\/\/[a-zA-Z0-9-]+[-]npm[.]pkg[.]dev\/.*\/):_password=(.*)/;
 

--- a/test/test.update.js
+++ b/test/test.update.js
@@ -225,6 +225,33 @@ describe('#update', () => {
       assert.equal(gotTo, `//us-west1-npm.pkg.dev/my-project/my-repo/:_authToken=abcd`);
     });
 
+
+    it('add new scoped with dot', async function(){
+      fromConfigPath = getConfigPath(`${this.test.title}-from`);
+      toConfigPath = getConfigPath(`${this.test.title}-to`)
+      fs.writeFileSync(fromConfigPath, `@my.scope:registry=https://us-west1-npm.pkg.dev/my-project/my-repo/`);
+      fs.writeFileSync(toConfigPath, ``);
+      await update.updateConfigFiles(fromConfigPath, toConfigPath, creds);
+      
+      const gotFrom = fs.readFileSync(fromConfigPath, 'utf8');
+      const gotTo = fs.readFileSync(toConfigPath, 'utf8');
+      assert.equal(gotFrom, `@my.scope:registry=https://us-west1-npm.pkg.dev/my-project/my-repo/`);
+      assert.equal(gotTo, `//us-west1-npm.pkg.dev/my-project/my-repo/:_authToken=abcd`);
+    });
+
+    it('add new scoped starting with tilda', async function(){
+      fromConfigPath = getConfigPath(`${this.test.title}-from`);
+      toConfigPath = getConfigPath(`${this.test.title}-to`)
+      fs.writeFileSync(fromConfigPath, `@~myscope:registry=https://us-west1-npm.pkg.dev/my-project/my-repo/`);
+      fs.writeFileSync(toConfigPath, ``);
+      await update.updateConfigFiles(fromConfigPath, toConfigPath, creds);
+      
+      const gotFrom = fs.readFileSync(fromConfigPath, 'utf8');
+      const gotTo = fs.readFileSync(toConfigPath, 'utf8');
+      assert.equal(gotFrom, `@~myscope:registry=https://us-west1-npm.pkg.dev/my-project/my-repo/`);
+      assert.equal(gotTo, `//us-west1-npm.pkg.dev/my-project/my-repo/:_authToken=abcd`);
+    });
+
     it('add new to config file does not exist', async function(){
       fromConfigPath = getConfigPath(`${this.test.title}-from`);
       toConfigPath = getConfigPath(`${this.test.title}-to`)


### PR DESCRIPTION
fix #37 

From: https://docs.npmjs.com/cli/v8/using-npm/scope#description:

> A scope follows the usual rules for package names (URL-safe characters, no leading dots or underscores)