### PR TITLE
chore: release 3.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "google-artifactregistry-auth",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "google-artifactregistry-auth",
-      "version": "3.0.2",
+      "version": "3.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "google-auth-library": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-artifactregistry-auth",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "description": "google-artifactregistry-auth is an npm module that allows you to configure npm to interact with npm repositories stored in Artifact Registry.",
   "main": "./src/main.js",
   "repository": "GoogleCloudPlatform/artifact-registry-npm-tools",


### PR DESCRIPTION
Default `--repo-config` to the user-level .npmrc is the project-level .npmrc doesn't exist.