### PR TITLE
fix: skip the scope check

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -54,16 +54,7 @@ async function getApplicationDefaultCredentials() {
     projectId: 'unused-project'
   });
   const client = await auth.getClient();
-  const creds = (await client.getAccessToken()).token;
-  const tokenScopes = (await client.getTokenInfo(creds)).scopes;
-  if (!tokenScopes.includes(
-          'https://www.googleapis.com/auth/cloud-platform')) {
-    throw new Error(
-        'Token has insufficient authentication scopes.\n' +
-        'Please configure access scope following instructions on ' +
-        'https://cloud.google.com/artifact-registry/docs/access-control#compute');
-  }
-  return creds; 
+  return (await client.getAccessToken()).token;
 }
 
 /**


### PR DESCRIPTION
Skip scope check when requesting a new token from ADC.
- We are already requesting the token with the cloud-platform scope so it doesn't seem necessary to check it again
- Not all auth clients implement `OAuth2Client`. e.g., [IdentityPoolClient](https://github.com/googleapis/google-auth-library-nodejs/blob/ed7ef7a5d1fa6bf5d06bdaab278052fd3930fb7f/src/auth/identitypoolclient.ts#L62).

Fix #49.