### PR TITLE
Support multiple repos in user npmrc

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-artifactregistry-auth",
-  "version": "3.1.2",
+  "version": "3.1.1",
   "description": "google-artifactregistry-auth is an npm module that allows you to configure npm to interact with npm repositories stored in Artifact Registry.",
   "main": "./src/main.js",
   "repository": "GoogleCloudPlatform/artifact-registry-npm-tools",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-artifactregistry-auth",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "google-artifactregistry-auth is an npm module that allows you to configure npm to interact with npm repositories stored in Artifact Registry.",
   "main": "./src/main.js",
   "repository": "GoogleCloudPlatform/artifact-registry-npm-tools",

--- a/src/update.js
+++ b/src/update.js
@@ -29,11 +29,6 @@ const {logger} = require('./logger');
 async function updateConfigFiles(fromConfigPath, toConfigPath, creds) {
   fromConfigPath = path.resolve(fromConfigPath);
   toConfigPath = path.resolve(toConfigPath);
-  // Backward-compatible scenario. Update auth configs in project npmrc directly.
-  if (fromConfigPath == toConfigPath) {
-    updateConfigFile(fromConfigPath, creds);
-    return;
-  }
 
   const fromConfigs = [];
   const toConfigs = [];
@@ -102,7 +97,11 @@ async function updateConfigFiles(fromConfigPath, toConfigPath, creds) {
   // Write to the user npmrc file first so that if it failed the project npmrc file
   // would still be untouched.
   await fs.promises.writeFile(toConfigPath, toConfigs.join(`\n`));
-  await fs.promises.writeFile(fromConfigPath, fromConfigs.join(`\n`));
+  if(fromConfigPath !== toConfigPath) {
+    // If the files are the same (and likely the user .npmrc file) only write once with the auth configs
+    // Otherwise, we'd overwrite this file without adding the credentials
+    await fs.promises.writeFile(fromConfigPath, fromConfigs.join(`\n`));
+  }
 }
 
 /**

--- a/test/test.update.js
+++ b/test/test.update.js
@@ -277,6 +277,20 @@ describe('#update', () => {
       assert.equal(gotTo, `//us-west1-npm.pkg.dev/my-project/my-repo/:_authToken=abcd`);
     });
 
+    it('set multiple tokens in same file', async function(){
+      fromConfigPath = getConfigPath(`${this.test.title}-from`);
+      toConfigPath = fromConfigPath;
+      fs.writeFileSync(fromConfigPath, `registry=https://us-west1-npm.pkg.dev/my-project/my-repo/
+      @cba:registry=https://asia-npm.pkg.dev/my-project/my-other-repo/`);
+      await update.updateConfigFiles(fromConfigPath, toConfigPath, creds);
+      
+      const got = fs.readFileSync(fromConfigPath, 'utf8');
+      assert.equal(got, `registry=https://us-west1-npm.pkg.dev/my-project/my-repo/
+@cba:registry=https://asia-npm.pkg.dev/my-project/my-other-repo/
+//us-west1-npm.pkg.dev/my-project/my-repo/:_authToken=abcd
+//asia-npm.pkg.dev/my-project/my-other-repo/:_authToken=abcd`);
+    });
+
     it('use password config if exists', async function(){
       fromConfigPath = getConfigPath(`${this.test.title}-from`);
       toConfigPath = getConfigPath(`${this.test.title}-to`)


### PR DESCRIPTION
When a user has two or more registries in their .npmrc file, the current logic doesn't work. `updateConfigFiles` must be used to update multiple lines in the file. 