### PR TITLE
add a flag --inline-update-insert-token for allowing adding auth tokens without placeholders when updating in place

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12, 14, 15, 16]
+        node-version: [14, 16, 18, 19]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
@@ -24,7 +24,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 15.x, 16.x]
+        node-version: [14.x, 16.x, 18.x, 19.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
@@ -37,7 +37,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 15.x, 16.x]
+        node-version: [14.x, 16.x, 18.x, 19.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/src/main.js
+++ b/src/main.js
@@ -75,6 +75,11 @@ async function main() {
         describe: 'Set log level to verbose',
         default: false,
       })
+      .option('inline-update-insert-token', {
+        type: 'boolean',
+        describe: 'If set, create an OAuth token for each registry config if no other types of auth config are present, even when updating in place',
+        default: false,
+      })
       .help()
       .argv;
 
@@ -84,9 +89,9 @@ async function main() {
     if (configPath) {
       console.warn('Updating project .npmrc inline is deprecated and may no longer be supported\n'
           + 'in future versions. Run the plugin with `--repo-config` and `--credential-config`.');
-      await update.updateConfigFile(configPath, creds);
+      await update.updateConfigFiles(configPath, configPath, creds, false);
     } else {
-      await update.updateConfigFiles(allArgs.repoConfig, allArgs.credentialConfig, creds);
+      await update.updateConfigFiles(allArgs.repoConfig, allArgs.credentialConfig, creds, allArgs.inlineUpdateInsertToken);
     }
     console.log("Success!");
   } catch (err) {

--- a/src/update.js
+++ b/src/update.js
@@ -26,10 +26,14 @@ const {logger} = require('./logger');
  * @param {string} creds Encrypted credentials.
  * @return {!Promise<undefined>}
  */
-async function updateConfigFiles(fromConfigPath, toConfigPath, creds) {
+async function updateConfigFiles(fromConfigPath, toConfigPath, creds, inlineUpdateInsertToken) {
   fromConfigPath = path.resolve(fromConfigPath);
   toConfigPath = path.resolve(toConfigPath);
-
+  // Backward-compatible scenario. Update auth configs in project npmrc directly.
+  if (fromConfigPath == toConfigPath && !inlineUpdateInsertToken) {
+    await updateConfigFile(fromConfigPath, creds);
+    return;
+  }
   const fromConfigs = [];
   const toConfigs = [];
   const registryAuthConfigs = new Map();
@@ -145,6 +149,5 @@ async function updateConfigFile(configPath, creds) {
 }
 
 module.exports = {
-  updateConfigFiles,
-  updateConfigFile
+  updateConfigFiles
 };

--- a/test/test.update.js
+++ b/test/test.update.js
@@ -32,7 +32,7 @@ function getConfigPath(test) {
 }
 
 describe('#update', () => {
-  describe('#updateConfigFile(configPath, creds)', () => {
+  describe('legacy in place update backward compatibility', () => {
     const newConfig = `registry=https://us-west1-npm.pkg.dev/my-project/my-repo/
 //us-west1-npm.pkg.dev/my-project/my-repo/:_authToken=""
 //us-west1-npm.pkg.dev/my-project/my-repo/:always-auth=true`;
@@ -122,13 +122,13 @@ describe('#update', () => {
     });
 
     afterEach(function(){
-      fs.rmdirSync(getTestDir(this.currentTest.title), {recursive: true});
+      fs.rmSync(getTestDir(this.currentTest.title), {recursive: true});
     });
 
     it('add new', async function(){
       configPath = getConfigPath(this.test.title);
       fs.writeFileSync(configPath, newConfig);
-      await update.updateConfigFile(configPath, creds);
+      await update.updateConfigFiles(configPath, configPath, creds, false);
 
       const got = fs.readFileSync(configPath, 'utf8');
       assert.equal(got, wantContent);
@@ -137,7 +137,7 @@ describe('#update', () => {
     it('replace old creds', async function(){
       configPath = getConfigPath(this.test.title);
       fs.writeFileSync(configPath, existingConfig);
-      await update.updateConfigFile(configPath, creds);
+      await update.updateConfigFiles(configPath, configPath, creds, false);
 
       const got = fs.readFileSync(configPath, 'utf8');
       assert.equal(got, wantContent);
@@ -146,7 +146,7 @@ describe('#update', () => {
     it('replace multiple creds', async function(){
       configPath = getConfigPath(this.test.title);
       fs.writeFileSync(configPath, multipleConfig);
-      await update.updateConfigFile(configPath, creds);
+      await update.updateConfigFiles(configPath, configPath, creds, false);
 
       const got = fs.readFileSync(configPath, 'utf8');
       assert.equal(got, wantMultipleContent);
@@ -155,7 +155,7 @@ describe('#update', () => {
     it('replace creds with legacy', async function(){
       configPath = getConfigPath(this.test.title);
       fs.writeFileSync(configPath, existingWithLegacyConfig);
-      await update.updateConfigFile(configPath, creds);
+      await update.updateConfigFiles(configPath, configPath, creds, false);
 
       const got = fs.readFileSync(configPath, 'utf8');
       assert.equal(got, wantExistingWithLegacyContent);
@@ -164,8 +164,7 @@ describe('#update', () => {
     it('replace legacy creds', async function(){
       configPath = getConfigPath(this.test.title);
       fs.writeFileSync(configPath, legacyConfig);
-      await update.updateConfigFile(configPath, creds);
-
+      await update.updateConfigFiles(configPath, configPath, creds, false);
       const got = fs.readFileSync(configPath, 'utf8');
       assert.equal(got, wantLegacyContent);
     });
@@ -173,12 +172,12 @@ describe('#update', () => {
     it('no creds', async function() {
       configPath = getConfigPath(this.test.title);
       fs.writeFileSync(configPath, nonCBAConfig);
-      await assert.rejects(update.updateConfigFile(configPath, creds));
+      await assert.rejects(update.updateConfigFiles(configPath, configPath, creds, false));
     });
 
     it ('non-existing', async function() {
       configPath = getConfigPath(this.test.title);
-      await assert.rejects(update.updateConfigFile(configPath, creds));
+      await assert.rejects(update.updateConfigFiles(configPath, configPath, creds, false));
     });
   });
 
@@ -204,7 +203,7 @@ describe('#update', () => {
       toConfigPath = getConfigPath(`${this.test.title}-to`)
       fs.writeFileSync(fromConfigPath, `registry=https://us-west1-npm.pkg.dev/my-project/my-repo/`);
       fs.writeFileSync(toConfigPath, ``);
-      await update.updateConfigFiles(fromConfigPath, toConfigPath, creds);
+      await update.updateConfigFiles(fromConfigPath, toConfigPath, creds, false);
       
       const gotFrom = fs.readFileSync(fromConfigPath, 'utf8');
       const gotTo = fs.readFileSync(toConfigPath, 'utf8');
@@ -217,7 +216,7 @@ describe('#update', () => {
       toConfigPath = getConfigPath(`${this.test.title}-to`)
       fs.writeFileSync(fromConfigPath, `@myscope:registry=https://us-west1-npm.pkg.dev/my-project/my-repo/`);
       fs.writeFileSync(toConfigPath, ``);
-      await update.updateConfigFiles(fromConfigPath, toConfigPath, creds);
+      await update.updateConfigFiles(fromConfigPath, toConfigPath, creds, false);
       
       const gotFrom = fs.readFileSync(fromConfigPath, 'utf8');
       const gotTo = fs.readFileSync(toConfigPath, 'utf8');
@@ -231,7 +230,7 @@ describe('#update', () => {
       toConfigPath = getConfigPath(`${this.test.title}-to`)
       fs.writeFileSync(fromConfigPath, `@my.scope:registry=https://us-west1-npm.pkg.dev/my-project/my-repo/`);
       fs.writeFileSync(toConfigPath, ``);
-      await update.updateConfigFiles(fromConfigPath, toConfigPath, creds);
+      await update.updateConfigFiles(fromConfigPath, toConfigPath, creds, false);
       
       const gotFrom = fs.readFileSync(fromConfigPath, 'utf8');
       const gotTo = fs.readFileSync(toConfigPath, 'utf8');
@@ -244,7 +243,7 @@ describe('#update', () => {
       toConfigPath = getConfigPath(`${this.test.title}-to`)
       fs.writeFileSync(fromConfigPath, `@~myscope:registry=https://us-west1-npm.pkg.dev/my-project/my-repo/`);
       fs.writeFileSync(toConfigPath, ``);
-      await update.updateConfigFiles(fromConfigPath, toConfigPath, creds);
+      await update.updateConfigFiles(fromConfigPath, toConfigPath, creds, false);
       
       const gotFrom = fs.readFileSync(fromConfigPath, 'utf8');
       const gotTo = fs.readFileSync(toConfigPath, 'utf8');
@@ -256,7 +255,7 @@ describe('#update', () => {
       fromConfigPath = getConfigPath(`${this.test.title}-from`);
       toConfigPath = getConfigPath(`${this.test.title}-to`)
       fs.writeFileSync(fromConfigPath, `@myscope:registry=https://us-west1-npm.pkg.dev/my-project/my-repo/`);
-      await update.updateConfigFiles(fromConfigPath, toConfigPath, creds);
+      await update.updateConfigFiles(fromConfigPath, toConfigPath, creds, false);
       
       const gotFrom = fs.readFileSync(fromConfigPath, 'utf8');
       const gotTo = fs.readFileSync(toConfigPath, 'utf8');
@@ -269,7 +268,7 @@ describe('#update', () => {
       toConfigPath = getConfigPath(`${this.test.title}-to`)
       fs.writeFileSync(fromConfigPath, `@myscope:registry=https://us-west1-npm.pkg.dev/my-project/my-repo/`);
       fs.writeFileSync(toConfigPath, `//us-west1-npm.pkg.dev/my-project/my-repo/:_authToken=oldToken`);
-      await update.updateConfigFiles(fromConfigPath, toConfigPath, creds);
+      await update.updateConfigFiles(fromConfigPath, toConfigPath, creds, false);
       
       const gotFrom = fs.readFileSync(fromConfigPath, 'utf8');
       const gotTo = fs.readFileSync(toConfigPath, 'utf8');
@@ -277,26 +276,12 @@ describe('#update', () => {
       assert.equal(gotTo, `//us-west1-npm.pkg.dev/my-project/my-repo/:_authToken=abcd`);
     });
 
-    it('set multiple tokens in same file', async function(){
-      fromConfigPath = getConfigPath(`${this.test.title}-from`);
-      toConfigPath = fromConfigPath;
-      fs.writeFileSync(fromConfigPath, `registry=https://us-west1-npm.pkg.dev/my-project/my-repo/
-      @cba:registry=https://asia-npm.pkg.dev/my-project/my-other-repo/`);
-      await update.updateConfigFiles(fromConfigPath, toConfigPath, creds);
-      
-      const got = fs.readFileSync(fromConfigPath, 'utf8');
-      assert.equal(got, `registry=https://us-west1-npm.pkg.dev/my-project/my-repo/
-@cba:registry=https://asia-npm.pkg.dev/my-project/my-other-repo/
-//us-west1-npm.pkg.dev/my-project/my-repo/:_authToken=abcd
-//asia-npm.pkg.dev/my-project/my-other-repo/:_authToken=abcd`);
-    });
-
     it('use password config if exists', async function(){
       fromConfigPath = getConfigPath(`${this.test.title}-from`);
       toConfigPath = getConfigPath(`${this.test.title}-to`)
       fs.writeFileSync(fromConfigPath, `@myscope:registry=https://us-west1-npm.pkg.dev/my-project/my-repo/`);
       fs.writeFileSync(toConfigPath, `//us-west1-npm.pkg.dev/my-project/my-repo/:_password=mypassword`);
-      await update.updateConfigFiles(fromConfigPath, toConfigPath, creds);
+      await update.updateConfigFiles(fromConfigPath, toConfigPath, creds, false);
       
       const gotFrom = fs.readFileSync(fromConfigPath, 'utf8');
       const gotTo = fs.readFileSync(toConfigPath, 'utf8');
@@ -310,7 +295,7 @@ describe('#update', () => {
       fs.writeFileSync(fromConfigPath, `@myscope:registry=https://us-west1-npm.pkg.dev/my-project/my-repo/
 //us-west1-npm.pkg.dev/my-project/my-repo/:_authToken=oldToken`);
       fs.writeFileSync(toConfigPath, `//us-west1-npm.pkg.dev/my-project/my-repo/:_authToken=oldToken`);
-      await update.updateConfigFiles(fromConfigPath, toConfigPath, creds);
+      await update.updateConfigFiles(fromConfigPath, toConfigPath, creds, false);
       
       const gotFrom = fs.readFileSync(fromConfigPath, 'utf8');
       const gotTo = fs.readFileSync(toConfigPath, 'utf8');
@@ -323,7 +308,7 @@ describe('#update', () => {
       toConfigPath = getConfigPath(`${this.test.title}-to`)
       fs.writeFileSync(fromConfigPath, `@myscope:registry=https://us-west1-npm.pkg.dev/my-project/my-repo/
 //us-west1-npm.pkg.dev/my-project/my-repo/:_password=mypassword`);
-      await update.updateConfigFiles(fromConfigPath, toConfigPath, creds);
+      await update.updateConfigFiles(fromConfigPath, toConfigPath, creds, false);
       
       const gotFrom = fs.readFileSync(fromConfigPath, 'utf8');
       const gotTo = fs.readFileSync(toConfigPath, 'utf8');
@@ -337,7 +322,7 @@ describe('#update', () => {
       fs.writeFileSync(fromConfigPath, `@myscope:registry=https://us-west1-npm.pkg.dev/my-project/my-repo/
 //us-west1-npm.pkg.dev/my-project/my-repo/:_password="YWJjZA=="
 //us-west1-npm.pkg.dev/my-project/my-repo/:username=oauth2accesstoken`);
-      await update.updateConfigFiles(fromConfigPath, toConfigPath, creds);
+      await update.updateConfigFiles(fromConfigPath, toConfigPath, creds, false);
       
       const gotFrom = fs.readFileSync(fromConfigPath, 'utf8');
       const gotTo = fs.readFileSync(toConfigPath, 'utf8');
@@ -352,7 +337,7 @@ describe('#update', () => {
 @anotherscope:registry=https://us-west1-npm.pkg.dev/another-proj/another-repo/
 myregistry.myproperty=myvalue`);
       fs.writeFileSync(toConfigPath, `myregistry.myproperty=myvalue`);
-      await update.updateConfigFiles(fromConfigPath, toConfigPath, creds);
+      await update.updateConfigFiles(fromConfigPath, toConfigPath, creds, false);
       
       const gotFrom = fs.readFileSync(fromConfigPath, 'utf8');
       const gotTo = fs.readFileSync(toConfigPath, 'utf8');
@@ -363,6 +348,43 @@ myregistry.myproperty=myvalue`);
 //us-west1-npm.pkg.dev/my-project/my-repo/:_authToken=abcd
 //us-west1-npm.pkg.dev/another-proj/another-repo/:_authToken=abcd`);
     });
+
+    it('inline update - set multiple tokens in same file', async function(){
+      fromConfigPath = getConfigPath(`${this.test.title}-from`);
+      toConfigPath = fromConfigPath;
+      fs.writeFileSync(fromConfigPath, `registry=https://us-west1-npm.pkg.dev/my-project/my-repo/
+@cba:registry=https://asia-npm.pkg.dev/my-project/my-other-repo/`);
+      await update.updateConfigFiles(fromConfigPath, toConfigPath, creds, true);
+      
+      const got = fs.readFileSync(fromConfigPath, 'utf8');
+      assert.equal(got, `registry=https://us-west1-npm.pkg.dev/my-project/my-repo/
+@cba:registry=https://asia-npm.pkg.dev/my-project/my-other-repo/
+//us-west1-npm.pkg.dev/my-project/my-repo/:_authToken=abcd
+//asia-npm.pkg.dev/my-project/my-other-repo/:_authToken=abcd`);
+    });
+
+    it('inline update - set multiple tokens in same file', async function(){
+      fromConfigPath = getConfigPath(`${this.test.title}-from`);
+      toConfigPath = fromConfigPath;
+      fs.writeFileSync(fromConfigPath, `@myscope:registry=https://us-west1-npm.pkg.dev/my-project/my-repo/
+//us-west1-npm.pkg.dev/my-project/my-repo/:_authToken=oldToken`);
+      await update.updateConfigFiles(fromConfigPath, toConfigPath, creds, true);
+      const gotFrom = fs.readFileSync(fromConfigPath, 'utf8');
+      assert.equal(gotFrom, `@myscope:registry=https://us-west1-npm.pkg.dev/my-project/my-repo/
+//us-west1-npm.pkg.dev/my-project/my-repo/:_authToken=abcd`);
+    });
+
+    it('inline update - keeps password config unchanged', async function(){
+      fromConfigPath = getConfigPath(`${this.test.title}-from`);
+      toConfigPath = fromConfigPath;
+      fs.writeFileSync(fromConfigPath, `@myscope:registry=https://us-west1-npm.pkg.dev/my-project/my-repo/
+//us-west1-npm.pkg.dev/my-project/my-repo/:_password=old.credential`);
+      await update.updateConfigFiles(fromConfigPath, toConfigPath, creds, true);
+      const gotFrom = fs.readFileSync(fromConfigPath, 'utf8');
+      assert.equal(gotFrom, `@myscope:registry=https://us-west1-npm.pkg.dev/my-project/my-repo/
+//us-west1-npm.pkg.dev/my-project/my-repo/:_password=old.credential`);
+    });
+
 
     it('rejects if input does not exist', async function() {
       fromConfigPath = getConfigPath(`${this.test.title}-from`);


### PR DESCRIPTION
Add a flag `--inline-update-insert-token`. If the flag exists and the user is updating the npmrc file in place, the tool will automatically detect if the user is authenticating via a credentials key file or auth token (with the latter being the default option) without requiring the user to provide a placeholder for each registry.

This CL essentially guards #56 behind a flag.

(Also drop node 12 in the tests because it has been EOL.)

### Background
Previously we had two required setups at two different stages of the auth tool:

1. We required the user to put a `<registry-url>:password=""` if the user wants to authenticate with an auth token or a `<registry-url>:password=<service-account-key-hash>` if the ruser wants to authenticate with a service account key in the npmrc file.
2. Later, we decided to use `<registry-url>:_authToken=""` placeholder for auth token authentication instead. However, for backward compatibility the old placeholder was still supported.

At both stages the auth tool can only update auth tokens in place. It required users to put  the placeholder along with the scope to registry URL mapping in the same .npmrc file (the placeholder and the URL mapping are both emitted by `gcloud artifacts print-settings`). 

We later realized in-place update had security concerns because it may result in the auth token being checked into VCS like git, and thus changed the tool to read scope to registry URL mapping from one file (usually project level) and write auth tokens to another file (usually user level). Along with this change, we also no longer required users to have a placeholder for auth token 
 and instead would determine on the fly whether the user was using an auth token or a credentials key to authenticate.

For backward compatibility, we maintained the old behaviors if the user is updating an npmrc file <b>in place</b>.

### Incompatible change

#56 wanted the convenience of not having to have auth token placeholders in the npmrc file when updating it in place. The intention was solid yet it [changed the code execution](https://github.com/GoogleCloudPlatform/artifact-registry-npm-tools/pull/56/files#diff-44842232c7e73c7a43865a046dc9d551e772c4f0c923e439496f6eb66d60686dL32-L36) flow and users who were still using the `password` as a placeholder were no longer able to update their npmrc file (#58). It was not detected by tests because backward-compatibility test cases were calling `updateConfigFile` directly.

### Future

Maintaining backward-compatibility for the two legacy setups has been more and more painful. After this PR is in we should just do a major bump and drop support for those two scenarios.